### PR TITLE
chore: ignore local agent metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ node_modules/
 /python
 package-lock.json
 .hugo_build.lock
+.omc
+.claude


### PR DESCRIPTION
Keep local agent configuration directories out of repository changes.

Confidence: high
Scope-risk: narrow
Not-tested: Skipped by request